### PR TITLE
test: test_record_hander 테스트 코드 작성

### DIFF
--- a/tests/models/test_record_handler.py
+++ b/tests/models/test_record_handler.py
@@ -1,0 +1,29 @@
+import wave
+from embedded_voice_kkutu.models.io import RecordHandler
+
+if __name__ == "__main__":
+    # RecordHandler 객체 생성
+    handler = RecordHandler()
+
+    # 사용자에게 음성 녹음 시작 알림
+    print("테스트 시작! 말을 하고, 멈추면 자동으로 중단됩니다.")
+    
+    # 음성 녹음 실행
+    frames = handler.record_until_silence()
+    
+    # 결과 출력
+    if len(frames) > 0:
+        print(f"녹음 성공! 총 {len(frames)}개의 오디오 프레임이 캡처되었습니다.")
+
+            # 녹음된 데이터를 WAV 파일로 저장
+        with wave.open("test_output.wav", "wb") as wf:
+            wf.setnchannels(handler.CHANNELS)
+            wf.setsampwidth(2)  # pyaudio.paInt16은 2바이트
+            wf.setframerate(handler.RATE)
+            wf.writeframes(b''.join(frames))
+        print("녹음 데이터를 'test_output.wav' 파일로 저장했습니다!")
+    else:
+        print("녹음 실패! 오디오 프레임이 없습니다.")
+    
+    # 녹음된 데이터 확인
+    print("녹음 데이터 샘플:", frames[:2])  # 첫 두 프레임만 출력


### PR DESCRIPTION
사용자로부터 음성으로 입력받아 frame으로 리턴하는 record_handelr의
테스트 코드입니다. 직접 테스트 결과 frame 잘 반환되는 것을 확인할 수
있었고, wav파일로 저장하여 녹음이 잘 받아진 걸 확인했습니다.
다만, 아무 말도 하지 않을 때 녹음 실패가 떠야 하는데 그대로 frame으로
리턴하더라구요? 나중에 수정이 필요해 보입니다.